### PR TITLE
[Cudasift][SYCL][HIP][CUDA]Minor fixes and perf improvements

### DIFF
--- a/cudaSift/CUDA/CMakeLists.txt
+++ b/cudaSift/CUDA/CMakeLists.txt
@@ -1,3 +1,25 @@
+#  Modifications Copyright (C) 2023 Intel Corporation
+
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom
+#  the Software is furnished to do so, subject to the following conditions:
+
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+#  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+#  OR OTHER DEALINGS IN THE SOFTWARE.
+
+#  SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.10)
 project(cudaSift C CXX)
 
@@ -7,27 +29,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(DEVICE_TIMER            "Build using Device Timer" OFF)
 option(USE_SM                  "Specifies which streaming multiprocessor architecture to use"     )
 
+set(DEF_WL_CXX_FLAGS           " -msse2 ")
+set(DEF_GENERAL_CXX_FLAGS      " -O3 ")
+set(DEF_COMBINED_CXX_FLAGS     "${DEF_GENERAL_CXX_FLAGS} ${DEF_WL_CXX_FLAGS}")
+
 find_package(OpenCV REQUIRED)
 find_package(CUDA)
 if (NOT CUDA_FOUND)
   message(STATUS "CUDA not found. Project will not be built.")
 endif(NOT CUDA_FOUND)
-
-if (WIN32)
-  set(EXTRA_CXX_FLAGS "/DVERBOSE /D_CRT_SECURE_NO_WARNINGS ")
-  list(APPEND CUDA_NVCC_FLAGS "-arch=sm_35;--compiler-options;-O2;-DVERBOSE") 
-endif()
-if (UNIX)
-  # if (APPLE)
-  #   set(EXTRA_CXX_FLAGS "-DVERBOSE -msse2")
-  #   list(APPEND CUDA_NVCC_FLAGS "-arch=sm_35;--compiler-options;-O2;-DVERBOSE") 
-  # else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -msse2")
-    # list(APPEND CUDA_NVCC_FLAGS "-lineinfo;-ccbin;/usr/bin/gcc;--compiler-options;-O2;-D_FORCE_INLINES;-DVERBOSE_NOT")
-    # list(APPEND CUDA_NVCC_FLAGS "-lineinfo;-ccbin") 
-    # list(APPEND CUDA_NVCC_FLAGS "-g;-G;-lineinfo;-ccbin;/usr/bin/gcc-8;--compiler-options;-O2;-D_FORCE_INLINES;-DVERBOSE_NOT;") 
-  # endif()
-endif()
 
 set(cuda_sources  
   cudaImage.cu  
@@ -55,11 +65,28 @@ if(DEVICE_TIMER)
     add_compile_options(-DDEVICE_TIMER)
 endif()
 
-cuda_add_executable(cudasift ${cuda_sources} ${sources} OPTIONS -arch=sm_${USE_SM})
-set_target_properties(cudasift PROPERTIES
-  COMPILE_FLAGS "${EXTRA_CXX_FLAGS}"			   
-)
+# -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags (BOTH general and WL specific)
+# -DOVERRIDE_GENERAL_CXX_FLAGS=" -blah -blah " overrides the general flags only (and not the workload specific flags)
+# passing in both CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS is not allowed, in order to prevent ambiguity
 
+if(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "" AND NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(FATAL_ERROR "Both  CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS cannot be passed in together")
+elseif("${CMAKE_CXX_FLAGS}" STREQUAL "" AND "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "Using DEFAULT compilation flags")
+    set(CMAKE_CXX_FLAGS "${DEF_COMBINED_CXX_FLAGS}")
+elseif(NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "OVERRIDING GENERAL compilation flags")
+    set(CMAKE_CXX_FLAGS "${OVERRIDE_GENERAL_CXX_FLAGS}")
+    string(APPEND CMAKE_CXX_FLAGS ${DEF_WL_CXX_FLAGS})
+elseif(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "OVERRIDING GENERAL and WORKLOAD SPECIFIC compilation flags")
+endif()
+
+
+set(CUDA_SEPARABLE_COMPILATION ON)
+message(STATUS "CXX  Compilation flags to: ${CMAKE_CXX_FLAGS}")
+
+cuda_add_executable(cudasift ${cuda_sources} ${sources} OPTIONS -arch=sm_${USE_SM})
 target_link_libraries(cudasift ${CUDA_cudadevrt_LIBRARY} ${OpenCV_LIBS})
  
 install(FILES 

--- a/cudaSift/CUDA/mainSift.cpp
+++ b/cudaSift/CUDA/mainSift.cpp
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
   // data validation
   auto dataVerficationTimer_start = std::chrono::steady_clock::now();
-  Utility::RunDataVerification(thresh, matchPercentage);
+  int data_verification_flag = Utility::RunDataVerification(thresh, matchPercentage);
   auto dataVerficationTimer_stop = std::chrono::steady_clock::now();
   dataVerificationTime = std::chrono::duration<float, std::micro>(dataVerficationTimer_stop - dataVerficationTimer_start).count();
   // // Print out and store summary data
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
   std::cout << "Total workload time = " << totalProgramTime / 1000 << " ms"
             << "\n"
             << std::endl;
-  return 0;
+  return data_verification_flag;
 }
 
 void MatchAll(SiftData &siftData1, SiftData &siftData2, float *homography)

--- a/cudaSift/HIP/CMakeLists.txt
+++ b/cudaSift/HIP/CMakeLists.txt
@@ -1,33 +1,56 @@
+#  Modifications Copyright (C) 2023 Intel Corporation
+
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom
+#  the Software is furnished to do so, subject to the following conditions:
+
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+#  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+#  OR OTHER DEALINGS IN THE SOFTWARE.
+
+#  SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.10)
-
-if(NOT DEFINED HIP_PATH)
-  if(NOT DEFINED ENV{HIP_PATH})
-    set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
-  else()
-    set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
-  endif()
-endif()
-
-set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
-
-project(cudasift)
-
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -O3 -Wextra  -D__HIP_PLATFORM_AMD__=1")
-set(CMAKE_CXX_STANDARD 11)
+project(cudasift LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(DEF_WL_CXX_FLAGS " -D__HIP_PLATFORM_AMD__ ")
+set(DEF_GENERAL_CXX_FLAGS " -Wall -O3 -Wextra ")
+set(DEF_COMBINED_CXX_FLAGS "${DEF_GENERAL_CXX_FLAGS} ${DEF_WL_CXX_FLAGS}")
+
+if(NOT DEFINED ROCM_PATH)
+  if(NOT DEFINED ENV{ROCM_PATH})
+    set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to which HIP has been installed")
+  else()
+    set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which HIP has been installed")
+  endif()
+endif()
+
+set(CMAKE_MODULE_PATH "${ROCM_PATH}/hip/cmake" ${CMAKE_MODULE_PATH})
+set(HIP_INCLUDE_DIRS "${ROCM_PATH}/include" ${HIP_INCLUDE_DIRS})
+set(HIP_LIBRARIES "${ROCM_PATH}/lib" ${HIP_LIBRARIES})
+
 option(DEVICE_TIMER "Build using Device Timer" OFF)
 
-find_package(HIP QUIET)
+find_package(HIP REQUIRED)
 
 if(HIP_FOUND)
   message(STATUS "Found HIP: " ${HIP_VERSION})
 else()
   message(FATAL_ERROR "Could not find HIP!")
 endif()
-
-set(HIP_SEPARABLE_COMPILATION ON)
 
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
@@ -51,41 +74,35 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags (BOTH general and WL specific)
+# -DOVERRIDE_GENERAL_CXX_FLAGS=" -blah -blah " overrides the general flags only (and not the workload specific flags)
+# passing in both CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS is not allowed, in order to prevent ambiguity
+if(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "" AND NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+  message(FATAL_ERROR "Both  CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS cannot be passed in together")
+elseif("${CMAKE_CXX_FLAGS}" STREQUAL "" AND "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+  message(STATUS "Using DEFAULT compilation flags")
+  set(CMAKE_CXX_FLAGS "${DEF_COMBINED_CXX_FLAGS}")
+elseif(NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+  message(STATUS "OVERRIDING GENERAL compilation flags")
+  set(CMAKE_CXX_FLAGS "${OVERRIDE_GENERAL_CXX_FLAGS}")
+  string(APPEND CMAKE_CXX_FLAGS ${DEF_WL_CXX_FLAGS})
+elseif(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "")
+  message(STATUS "OVERRIDING GENERAL and WORKLOAD SPECIFIC compilation flags")
+endif()
+
+message(STATUS "CXX  Compilation flags to: ${CMAKE_CXX_FLAGS}")
+
 if(DEVICE_TIMER)
   message(STATUS "Enabling Device Timer")
   add_compile_options(-DDEVICE_TIMER)
 endif()
 
+set(HIP_SEPARABLE_COMPILATION ON)
 set(MY_TARGET_NAME ${PROJECT_NAME})
 set(MY_HIPCC_OPTIONS)
 set(MY_NVCC_OPTIONS)
 set(CMAKE_HIP_ARCHITECTURES OFF)
-set(CMAKE_NVCC_FLAGS ${CMAKE_NVCC_FLAGS} -std=c++11)
 
 set_source_files_properties(${cuda_sources} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
 hip_add_executable(${MY_TARGET_NAME} ${SOURCES} ${MY_HIPCC_OPTIONS} NVCC_OPTIONS ${MY_NVCC_OPTIONS})
 target_link_libraries(cudasift stdc++ stdc++fs ${OpenCV_LIBS})
-
-# SET(CUDA_SEPARABLE_COMPILATION ON)
-# hip_add_executable(cudasift ${cuda_sources} ${sources} OPTIONS -arch=sm_61)
-
-# cuda_add_executable(l2net l2netD.cu OPTIONS -arch=sm_35)
-# set_target_properties(cudasift PROPERTIES
-# COMPILE_FLAGS "${EXTRA_CXX_FLAGS}"
-# )
-
-# target_link_libraries(cudasift ${CUDA_cudadevrt_LIBRARY} ${OpenCV_LIBS})
-
-# /usr/local/cuda/lib64/libcudadevrt.a ${OpenCV_LIBS}
-# )
-# install(FILES
-# ${cuda_sources}
-# ${sources}
-# cudaSiftD.cu
-# CMakeLists.txt
-# Copyright.txt
-# DESTINATION .
-# )
-# install(FILES data/left.pgm data/righ.pgm
-# DESTINATION data
-# )

--- a/cudaSift/HIP/mainSift.cpp
+++ b/cudaSift/HIP/mainSift.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
 #endif
   // data validation
   auto dataVerficationTimer_start = std::chrono::steady_clock::now();
-  Utility::RunDataVerification(thresh, matchPercentage);
+  int data_verification_flag = Utility::RunDataVerification(thresh, matchPercentage);
   auto dataVerficationTimer_stop = std::chrono::steady_clock::now();
   dataVerificationTime = std::chrono::duration<float, std::micro>(dataVerficationTimer_stop - dataVerficationTimer_start).count();
   // // Print out and store summary data
@@ -163,6 +163,7 @@ int main(int argc, char **argv)
   std::cout << "Total workload time = " << totalProgramTime / 1000 << " ms"
             << "\n"
             << std::endl;
+  return data_verification_flag;
 }
 
 void MatchAll(SiftData &siftData1, SiftData &siftData2, float *homography)

--- a/cudaSift/README.md
+++ b/cudaSift/README.md
@@ -64,7 +64,8 @@ make -sj
 
 mkdir build && cd build
 
-CXX=hipcc cmake ../
+CXX=hipcc cmake ../ -DROCM_PATH=/path/to/rocm 
+For e.g CXX=hipcc cmake ../ -DROCM_PATH/opt/rocm-5.4.3
 
 make -sj
 

--- a/cudaSift/SYCL/CMakeLists.txt
+++ b/cudaSift/SYCL/CMakeLists.txt
@@ -1,18 +1,38 @@
+#  Modifications Copyright (C) 2023 Intel Corporation
+
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom
+#  the Software is furnished to do so, subject to the following conditions:
+
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+#  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+#  OR OTHER DEALINGS IN THE SOFTWARE.
+
+#  SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.10)
 project(cudaSift LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)           # SYCL code requires this
-set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Enable modern C++ standards
-set(CMAKE_CXX_EXTENSIONS OFF)        # Use -std, not -gnu
+set(CMAKE_CXX_STANDARD 17) # SYCL code requires this
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # Enable modern C++ standards
+set(CMAKE_CXX_EXTENSIONS OFF) # Use -std, not -gnu
 
-option(GPU_AOT                 "Build AOT for Intel GPU"      OFF)
-option(USE_NVIDIA_BACKEND      "Build for NVIDIA backend"     OFF)
-option(USE_AMDHIP_BACKEND      "Build for AMD HIP backend"    OFF)
-option(USE_INTEL_CPU           "Build for INTEL CPU"    OFF) 
-option(USE_SM                  "Specifies which streaming multiprocessor architecture to use"     )
-option(OpenCV_DIR              "Path to OpenCV_DIR"     )
-option(DEVICE_TIMER            "Build using Device Timer" OFF)
-
+option(GPU_AOT "Build AOT for Intel GPU" OFF)
+option(USE_NVIDIA_BACKEND "Build for NVIDIA backend" OFF)
+option(USE_AMDHIP_BACKEND "Build for AMD HIP backend" OFF)
+option(USE_SM "Specifies which streaming multiprocessor architecture to use")
+option(OpenCV_DIR "Path to OpenCV_DIR")
+option(DEVICE_TIMER "Build using Device Timer" OFF)
 
 # Find OpenCV, you may need to set OpenCV_DIR variable
 # to the absolute path to the directory containing OpenCVConfig.cmake file
@@ -23,16 +43,15 @@ find_package(OpenCV REQUIRED)
 # be set, you can find the full list with descriptions
 # in the OpenCVConfig.cmake file.
 # Print some message showing some of them
-    message(STATUS "OpenCV library status:")
-    message(STATUS "    version: ${OpenCV_VERSION}")
-    message(STATUS "    libraries: ${OpenCV_LIBS}")
-    message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}")
+message(STATUS "OpenCV library status:")
+message(STATUS "    version: ${OpenCV_VERSION}")
+message(STATUS "    libraries: ${OpenCV_LIBS}")
+message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}")
 
 if(CMAKE_VERSION VERSION_LESS "2.8.11")
-# Add OpenCV headers location to your include paths
-include_directories(${OpenCV_INCLUDE_DIRS})
+    # Add OpenCV headers location to your include paths
+    include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
-
 
 set(SOURCES
     ${CMAKE_SOURCE_DIR}/../common/Utility.cpp
@@ -58,51 +77,73 @@ if(DEVICE_TIMER)
     add_compile_options(-DDEVICE_TIMER)
 endif()
 
-# Use either default or user defined CXX flags
-# -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags
-
-set(USE_DEFAULT_FLAGS ON)
-set(INTEL_CPU_CXX_FLAGS  " -O2 -fsycl -Wall -Wextra -Wno-unused-parameter ") 
-set(INTEL_GPU_CXX_FLAGS  " -O2 -fsycl -ffast-math")
-set(NVIDIA_GPU_CXX_FLAGS " -O3 -fsycl -ffast-math ")
-set(AMD_GPU_CXX_FLAGS    " -O3 -fsycl -ffast-math ")
-
-if("${CMAKE_CXX_FLAGS}" STREQUAL "")
-    message(STATUS "Using DEFAULT compilation flags for the application")
-    string(APPEND CMAKE_CXX_FLAGS "${INTEL_GPU_CXX_FLAGS}") # Default flags for NV backend
-else()
-    message(STATUS "OVERRIDING compilation flags")
-    set(USE_DEFAULT_FLAGS OFF)
+if(USE_NVIDIA_BACKEND)
+    message(STATUS "Nvidia backend")
+    add_compile_options(-DUSE_NVIDIA_BACKEND)
 endif()
 
-# JIT compilation 
-if(GPU_AOT) 
-    if( (${GPU_AOT} STREQUAL "pvc") OR (${GPU_AOT} STREQUAL "PVC") )
+if(USE_AMDHIP_BACKEND)
+    message(STATUS "AMD backend")
+    add_compile_options(-DUSE_AMDHIP_BACKEND)
+endif()
+
+# Use either default or user defined CXX flags
+# -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags
+set(USE_DEFAULT_FLAGS ON)
+
+set(DEF_INTEL_WL_CXX_FLAGS  " ")
+set(DEF_NVIDIA_WL_CXX_FLAGS " ")
+set(DEF_AMD_WL_CXX_FLAGS    " -D__HIP_PLATFORM_AMD__ ")
+
+set(DEF_INTEL_GENERAL_CXX_FLAGS  " -O3 -fsycl -ffast-math ")
+set(DEF_NVIDIA_GENERAL_CXX_FLAGS " -O3 -fsycl -ffast-math ")
+set(DEF_AMD_GENERAL_CXX_FLAGS    " -O3 -fsycl -ffast-math ")
+
+# -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags (BOTH general and WL specific)
+# -DOVERRIDE_GENERAL_CXX_FLAGS=" -blah -blah " overrides the general flags only (and not the workload specific flags)
+# passing in both CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS is not allowed, in order to prevent ambiguity
+
+if(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "" AND NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(FATAL_ERROR "Both  CMAKE_CXX_FLAGS and OVERRIDE_GENERAL_CXX_FLAGS cannot be passed in together")
+elseif("${CMAKE_CXX_FLAGS}" STREQUAL "" AND "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "Using DEFAULT compilation flags")
+    set(INTEL_GPU_CXX_FLAGS        "${DEF_INTEL_GENERAL_CXX_FLAGS}   ${DEF_INTEL_WL_CXX_FLAGS}")
+    set(NVIDIA_GPU_CXX_FLAGS       "${DEF_NVIDIA_GENERAL_CXX_FLAGS}  ${DEF_NVIDIA_WL_CXX_FLAGS}")
+    set(AMD_GPU_CXX_FLAGS          "${DEF_AMD_GENERAL_CXX_FLAGS}     ${DEF_AMD_WL_CXX_FLAGS}")
+elseif(NOT "${OVERRIDE_GENERAL_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "OVERRIDING GENERAL compilation flags")
+    set(INTEL_GPU_CXX_FLAGS        "${OVERRIDE_GENERAL_CXX_FLAGS}    ${DEF_INTEL_WL_CXX_FLAGS}")
+    set(NVIDIA_GPU_CXX_FLAGS       "${OVERRIDE_GENERAL_CXX_FLAGS}    ${DEF_NVIDIA_WL_CXX_FLAGS}")
+    set(AMD_GPU_CXX_FLAGS          "${OVERRIDE_GENERAL_CXX_FLAGS}    ${DEF_AMD_WL_CXX_FLAGS}")
+elseif(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "")
+    message(STATUS "OVERRIDING GENERAL and WORKLOAD SPECIFIC compilation flags")
+    set(INTEL_GPU_CXX_FLAGS        "${CMAKE_CXX_FLAGS}")
+    set(NVIDIA_GPU_CXX_FLAGS       "${CMAKE_CXX_FLAGS}")
+    set(AMD_GPU_CXX_FLAGS          "${CMAKE_CXX_FLAGS}")
+endif()
+
+# JIT compilation
+if(GPU_AOT)    
+    message(STATUS "Enabling INTEL backend")        
+    set(CMAKE_CXX_FLAGS "${INTEL_GPU_CXX_FLAGS}")
+    if((${GPU_AOT} STREQUAL "pvc") OR(${GPU_AOT} STREQUAL "PVC"))
         message(STATUS "Enabling Intel GPU AOT compilation for ${GPU_AOT}")
         string(APPEND CMAKE_CXX_FLAGS " -fsycl-targets=spir64_gen -Xs \"-device 0x0bd5 -revision_id 0x2f\" -Xs \"-options -ze-opt-large-register-file\" ")
     else()
         message(STATUS "Using custom AOT compilation flag ${GPU_AOT}")
         string(APPEND CMAKE_CXX_FLAGS " ${GPU_AOT} ") # User should be aware of advanced AOT compilation flags
     endif()
-elseif(USE_NVIDIA_BACKEND)    
+elseif(USE_NVIDIA_BACKEND)
     message(STATUS "Enabling NVIDIA backend")
-    if(USE_DEFAULT_FLAGS)
-        set(CMAKE_CXX_FLAGS "${NVIDIA_GPU_CXX_FLAGS}") # Default flags for NV backend
-    endif()
-    string(APPEND CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_${USE_SM}") # -O3 will be used, even though -O2 was set earlier 
+    set(CMAKE_CXX_FLAGS "${NVIDIA_GPU_CXX_FLAGS}")
+    string(APPEND CMAKE_CXX_FLAGS " -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_${USE_SM}") 
 elseif(USE_AMDHIP_BACKEND)
     message(STATUS "Enabling AMD HIP backend for ${USE_AMDHIP_BACKEND} AMD architecture")
-    if(USE_DEFAULT_FLAGS)
-        set(CMAKE_CXX_FLAGS "${AMD_GPU_CXX_FLAGS}")
-    endif()
+    set(CMAKE_CXX_FLAGS "${AMD_GPU_CXX_FLAGS}")
     string(APPEND CMAKE_CXX_FLAGS " -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=${USE_AMDHIP_BACKEND}  ")
-elseif(USE_INTEL_CPU)
-    message(STATUS "Enabling INTEL CPU backend for ${USE_CPU_BACKEND} INTEL architecture")
-    if(USE_DEFAULT_FLAGS)   
-	    set(CMAKE_CXX_FLAGS "${INTEL_CPU_CXX_FLAGS}")				    
-    endif()
-    string(APPEND CMAKE_CXX_FLAGS " -fsycl-targets=spir64_x86_64 -Xsycl-target-backend \"--march=avx512\"  ")
-    # string(APPEND CMAKE_CXX_FLAGS "  -ffast-math -mprefer-vector-width=512 -mfma -fsycl-targets=spir64_x86_64--linux  \"-device avx512\"  ")
+else()
+    message(STATUS "Enabling INTEL backend")
+    set(CMAKE_CXX_FLAGS "${INTEL_GPU_CXX_FLAGS}")  
 endif()
 
 # Output the compiler flags that were constructed for visual inspection

--- a/cudaSift/SYCL/cudaImage.dp.cpp
+++ b/cudaSift/SYCL/cudaImage.dp.cpp
@@ -75,12 +75,9 @@ CudaImage::CudaImage() : width(0), height(0), pitch(0), d_data(NULL), h_data(NUL
 CudaImage::~CudaImage()
 {
   if (d_internalAlloc && d_data != NULL)
-    try
-    {
+    try{
       safeCall((sycl::free(d_data, infra::get_default_queue()), 0));
-    }
-    catch (std::exception const &e)
-    {
+    } catch (std::exception const &e) {
       std::cerr << e.what() << '\n';
     }
   d_data = NULL;

--- a/cudaSift/SYCL/cudaSiftH.dp.cpp
+++ b/cudaSift/SYCL/cudaSiftH.dp.cpp
@@ -422,7 +422,10 @@ double ScaleDown(CudaImage &res, CudaImage &src, float variance, sycl::queue &q_
 
                                      cgh.parallel_for(
                                          sycl::nd_range<3>(blocks * threads, threads),
-                                         [=](sycl::nd_item<3> item_ct1)[[intel::reqd_sub_group_size(32)]]
+                                         [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                             [[intel::reqd_sub_group_size(32)]]
+#endif
                                          {                                           
                                            ScaleDown(res_data_ct1, src_data_ct1, src_width, src_pitch, src_height,
                                                      res_pitch, item_ct1, d_ScaleDownKernel_ptr_ct1,
@@ -465,7 +468,10 @@ double ScaleUp(CudaImage &res, CudaImage &src, sycl::queue &q_ct, float &totTime
                                      auto res_pitch = res.pitch;
                                      cgh.parallel_for(
                                          sycl::nd_range<3>(blocks * threads, threads),
-                                         [=](sycl::nd_item<3> item_ct1)[[intel::reqd_sub_group_size(32)]]
+                                         [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                             [[intel::reqd_sub_group_size(32)]]
+#endif
                                          {                                           
                                            ScaleUp(res_data_ct1, src_data_ct1, src_width, src_pitch, src_height,
                                                    res_pitch, item_ct1);
@@ -518,7 +524,11 @@ double ComputeOrientations(CudaImage &src, SiftData &siftData, int octave, sycl:
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(blocks * threads, threads),
-                    [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+                    [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                        [[intel::reqd_sub_group_size(32)]]
+#endif
+                    {
                       ComputeOrientationsCONSTNew(
                           src_data_ct1, src_width, src_pitch, src_height, siftData_data_ct1,
                           octave, item_ct1, *d_MaxNumPoints_ptr_ct1, d_PointCounter_ptr_ct1,
@@ -563,16 +573,17 @@ double ExtractSiftDescriptors(float *texObj, int pitch, SiftData &siftData, floa
                                      auto siftData_data_ct1 = siftData.d_data;
 
                                      cgh.parallel_for(
-                                         sycl::nd_range<3>(blocks * threads, threads), [=
-                                     ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(
-                                                                                           32)]] {
-                                           ExtractSiftDescriptorsCONSTNew(                                              
+                                         sycl::nd_range<3>(blocks * threads, threads), [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                          [[intel::reqd_sub_group_size(32)]]
+#endif
+                                         { 
+                                               ExtractSiftDescriptorsCONSTNew(
                                                texObj, pitch,
                                                siftData_data_ct1, subsampling, octave, item_ct1,
                                                *d_MaxNumPoints_ptr_ct1, d_PointCounter_ptr_ct1,
                                                gauss_acc_ct1.get_pointer(), buffer_acc_ct1.get_pointer(),
-                                               sums_acc_ct1.get_pointer());
-                                         }); })
+                                               sums_acc_ct1.get_pointer()); }); })
       .wait();
 
 #ifdef DEVICE_TIMER
@@ -597,7 +608,10 @@ double RescalePositions(SiftData &siftData, float scale, sycl::queue &q_ct, floa
                                      auto sifData_numPts = siftData.numPts;
                                      cgh.parallel_for(
                                          sycl::nd_range<3>(blocks * threads, threads),
-                                         [=](sycl::nd_item<3> item_ct1)[[intel::reqd_sub_group_size(32)]]
+                                         [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                             [[intel::reqd_sub_group_size(32)]]
+#endif
                                          {
                                            RescalePositions(siftData_data_ct1, sifData_numPts, scale, item_ct1);
                                          }); })
@@ -662,9 +676,11 @@ double LowPass(CudaImage &res, CudaImage &src, float scale, sycl::queue &q_ct, f
                                          xrows_acc_ct1(sycl::range<2>(16, 32), cgh);
                                      cgh.parallel_for(
                                          sycl::nd_range<3>(blocks * threads, threads), [=](sycl::nd_item<3> item_ct1)
-                                         [[intel::reqd_sub_group_size(32)]]
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                          [[intel::reqd_sub_group_size(32)]]
+#endif
                                          { LowPassBlockOld(src_data_ct1, res_data_ct1, width, pitch, height, item_ct1,
-                                                        d_LowPassKernel_ptr_ct1, xrows_acc_ct1); }); })
+                                                           d_LowPassKernel_ptr_ct1, xrows_acc_ct1); }); })
         .wait();
 #ifdef DEVICE_TIMER
     auto stop_kernel = std::chrono::steady_clock::now();
@@ -732,7 +748,11 @@ double LaplaceMulti(CudaImage &baseImage, CudaImage *results, int octave, sycl::
         float *baseImage_data_ct1 = baseImage.d_data;
         cgh.parallel_for(
             sycl::nd_range<3>(blocks * threads, threads),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                [[intel::reqd_sub_group_size(32)]]
+#endif
+            {
               LaplaceMultiMem(baseImage_data_ct1, results_d_data_ct1,
                               width, pitch, height, octave, item_ct1,
                               d_LaplaceKernel_ptr_ct1,
@@ -785,15 +805,15 @@ double FindPointsMulti(CudaImage *sources, SiftData &siftData, float thresh, flo
                                      auto siftData_data_ct1 = siftData.d_data;
 
                                      cgh.parallel_for(
-                                         sycl::nd_range<3>(blocks * threads, threads), [=
-                                     ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]]
-                                         {                                           
-                                           FindPointsMultiNew(sources_d_data_ct0, siftData_data_ct1, w, p, h,
+                                         sycl::nd_range<3>(blocks * threads, threads), [=](sycl::nd_item<3> item_ct1)
+#if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
+                                          [[intel::reqd_sub_group_size(32)]]
+#endif
+                                         { FindPointsMultiNew(sources_d_data_ct0, siftData_data_ct1, w, p, h,
                                                               subsampling, lowestScale, thresh, factor,
                                                               edgeLimit, octave, item_ct1,
                                                               *d_MaxNumPoints_ptr_ct1, d_PointCounter_ptr_ct1,
-                                                              points_acc_ct1.get_pointer());
-                                         }); });
+                                                              points_acc_ct1.get_pointer()); }); });
   event_FindPointsMulti.wait();
 #ifdef DEVICE_TIMER
   auto stop_kernel = std::chrono::steady_clock::now();

--- a/cudaSift/SYCL/infra/atomic.hpp
+++ b/cudaSift/SYCL/infra/atomic.hpp
@@ -313,5 +313,5 @@ namespace infra
         fail);
   }
 
-}
-#endif
+} // namespace infra
+#endif // __INFRA_ATOMIC_HPP__

--- a/cudaSift/SYCL/infra/device.hpp
+++ b/cudaSift/SYCL/infra/device.hpp
@@ -149,6 +149,7 @@ namespace infra
     size_t _max_nd_range_size[3];
   };
 
+  /// infra device extension
   class device_ext : public sycl::device
   {
   public:
@@ -497,7 +498,7 @@ namespace infra
   };
 
   /// Util function to get the defualt queue of current device in
-  /// device manager.
+  /// infra device manager.
   static inline sycl::queue &get_default_queue()
   {
     return dev_mgr::instance().current_device().default_queue();
@@ -516,7 +517,7 @@ namespace infra
   }
 
   /// Util function to get the context of the default queue of current
-  /// device in device manager.
+  /// device in infra device manager.
   static inline sycl::context get_default_context()
   {
     return infra::get_current_device().get_context();
@@ -528,6 +529,6 @@ namespace infra
     return dev_mgr::instance().cpu_device();
   }
 
-}
+} // namespace infra
 
-#endif
+#endif // __INFRA_DEVICE_HPP__

--- a/cudaSift/SYCL/infra/memory.hpp
+++ b/cudaSift/SYCL/infra/memory.hpp
@@ -266,7 +266,7 @@ namespace infra
       return mem_mgr::instance().mem_alloc(size * sizeof(byte_t));
 #else
       return sycl::malloc_device(size, q.get_device(), q.get_context());
-#endif
+#endif // INFRA_USM_LEVEL_NONE
     }
 
 #define PITCH_DEFAULT_ALIGN(x) (((x) + 31) & ~(0x1F))
@@ -303,7 +303,7 @@ namespace infra
     cgh.fill(acc, (byte_t)value); });
 #else
       return q.memset(dev_ptr, value, size);
-#endif
+#endif // INFRA_USM_LEVEL_NONE
     }
 
     /// Set \p value to the 3D memory region pointed by \p data in \p q. \p size
@@ -506,7 +506,7 @@ namespace infra
       }
 #else
       return q.memcpy(to_ptr, from_ptr, size);
-#endif
+#endif // INFRA_USM_LEVEL_NONE
     }
 
     /// copy 3D matrix specified by \p size from 3D matrix specified by \p from_ptr
@@ -750,7 +750,7 @@ namespace infra
       detail::mem_mgr::instance().mem_free(ptr);
 #else
       sycl::free(ptr, q.get_context());
-#endif
+#endif // INFRA_USM_LEVEL_NONE
     }
   }
 
@@ -1018,6 +1018,7 @@ namespace infra
     detail::sift_memset(q, pitch, val, size);
   }
 
+  /// infra accessor used as device function parameter.
   template <class T, memory_region Memory, size_t Dimension>
   class accessor;
   template <class T, memory_region Memory>
@@ -1206,7 +1207,7 @@ namespace infra
             .template get_access<sycl::access_mode::read_write>()[index];
 #else
         return _device_ptr[index];
-#endif
+#endif // INFRA_USM_LEVEL_NONE
       }
 
 #ifdef INFRA_USM_LEVEL_NONE
@@ -1227,7 +1228,7 @@ namespace infra
       {
         return infra_accessor_t((T *)_device_ptr, _range);
       }
-#endif
+#endif // INFRA_USM_LEVEL_NONE
 
     private:
       device_memory(value_t *memory_ptr, size_t size)
@@ -1276,7 +1277,7 @@ namespace infra
                        .template reinterpret<T, 1>(sycl::range<1>(1));
         return accessor_t(buf, cgh);
       }
-#endif
+#endif // INFRA_USM_LEVEL_NONE
     };
   }
 
@@ -1286,6 +1287,6 @@ namespace infra
   using constant_memory = detail::device_memory<T, constant, Dimension>;
   template <class T, size_t Dimension>
   using shared_memory = detail::device_memory<T, shared, Dimension>;
-}
+} // namespace infra
 
-#endif
+#endif // __INFRA_MEMORY_HPP__

--- a/cudaSift/SYCL/mainSift.cpp
+++ b/cudaSift/SYCL/mainSift.cpp
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
 #endif
   // data validation
   auto dataVerficationTimer_start = std::chrono::steady_clock::now();
-  Utility::RunDataVerification(thresh, matchPercentage);
+  int data_verification_flag = Utility::RunDataVerification(thresh, matchPercentage);
   auto dataVerficationTimer_stop = std::chrono::steady_clock::now();
   float dataVerificationTime =
       std::chrono::duration<float, std::micro>(dataVerficationTimer_stop - dataVerficationTimer_start).count();
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
   std::cout << "Total workload time = " << totalProgramTime / 1000 << " ms"
             << "\n"
             << std::endl;
-  return 0;
+  return data_verification_flag;
 }
 
 void MatchAll(SiftData &siftData1, SiftData &siftData2, float *homography)

--- a/cudaSift/common/Utility.cpp
+++ b/cudaSift/common/Utility.cpp
@@ -26,7 +26,7 @@
 
 using namespace Utility;
 
-void Utility::RunDataVerification(const int threshold, const float matchPercentage)
+int Utility::RunDataVerification(const int threshold, const float matchPercentage)
 {
     printf("Performing data verification \n");
     switch (threshold)
@@ -39,6 +39,7 @@ void Utility::RunDataVerification(const int threshold, const float matchPercenta
         else
         {
             printf("Data verification FAILED. \n\n");
+            return -1;
         }
         break;
     case 2:
@@ -49,6 +50,7 @@ void Utility::RunDataVerification(const int threshold, const float matchPercenta
         else
         {
             printf("Data verification FAILED. \n\n");
+            return -1;
         }
         break;
     case 3:
@@ -59,6 +61,7 @@ void Utility::RunDataVerification(const int threshold, const float matchPercenta
         else
         {
             printf("Data verification FAILED. \n\n");
+            return -1;
         }
         break;
     case 4:
@@ -69,9 +72,12 @@ void Utility::RunDataVerification(const int threshold, const float matchPercenta
         else
         {
             printf("Data verification FAILED. \n\n");
+            return -1;
         }
         break;
     default:
         printf("Threshold values should be in the range [1, 4]. \n\n");
+        return -1;
     }
+    return 0;
 }

--- a/cudaSift/common/Utility.h
+++ b/cudaSift/common/Utility.h
@@ -25,7 +25,7 @@
 
 namespace Utility
 {
-    void RunDataVerification(const int thresh, const float matchPercentage);
+    int RunDataVerification(const int thresh, const float matchPercentage);
 
 }
 #endif // UTILITY_H


### PR DESCRIPTION
- Updated cmake files, allows passing in additional flags which overrides default flags.
- Updated main program in all three versions to return -1 when data verification failed.
- Fixed sycl math call to use sycl::pow instead of sycl::pow<float> which causes compilation issue.
- Updated SYCL version to not use sub group size while on nvidia and amd backends.
- Used local_space inside barriers and loop unrolling which improved SYCL performance by 7%