### PR TITLE
[svm][SYCL] Use oneMKL interface instead of oneMKL library

### DIFF
--- a/svm/SYCL/CMakeLists.txt
+++ b/svm/SYCL/CMakeLists.txt
@@ -76,6 +76,8 @@ set(SOURCES
     #infrastructure/SYCL.cpp
 )
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 include_directories(${CMAKE_SOURCE_DIR}
                     ${CMAKE_SOURCE_DIR}/libSVM
                     ${CMAKE_SOURCE_DIR}/cuSVM
@@ -86,7 +88,7 @@ include_directories(${CMAKE_SOURCE_DIR}
 # Use either default or user defined CXX flags
 # -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags
 
-set(INTEL_GPU_CXX_FLAGS  " -O3 -fsycl -DMKL_ILP64")
+set(INTEL_GPU_CXX_FLAGS  " -O3 -fsycl")
 set(NVIDIA_GPU_CXX_FLAGS " -O3 -fsycl -DUSE_CUBLAS")
 set(AMD_GPU_CXX_FLAGS    " -O3 -fsycl -DUSE_HIPBLAS -D__HIP_PLATFORM_AMD__")
 
@@ -110,8 +112,9 @@ elseif(USE_AMD_BACKEND)
     target_link_libraries(${PROJECT_NAME} -lhipblas)
 else()
     message(STATUS "Enabling INTEL backend")
-    link_directories(${MKLROOT}/lib/intel64)
-    target_link_libraries(${PROJECT_NAME} mkl_sycl mkl_intel_ilp64 mkl_tbb_thread mkl_core pthread dl m)
+    find_package(oneMKL REQUIRED CONFIG HINTS ${oneMKLROOT})
+    message(STATUS "Found oneMKL: ${oneMKL_DIR}")
+    target_link_libraries(${PROJECT_NAME} PRIVATE MKL::onemkl)
 endif()
 
 if(GPU_AOT)
@@ -141,4 +144,4 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/a9a
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 #add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} sycl stdc++fs)
+target_link_libraries(${PROJECT_NAME} PRIVATE sycl stdc++fs)

--- a/svm/SYCL/cmake/FindSYCL.cmake
+++ b/svm/SYCL/cmake/FindSYCL.cmake
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom
+# the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+# OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+#
+################################################################################
+# oneMKL provides a FindCompiler.cmake file which can be reused to handle calls
+# to find_package(SYCL ...) (found in oneMKLConfig.cmake). Reuse that and set
+# SYCL_Found to true on success.
+################################################################################
+
+include(FindCompiler)
+
+find_package(Compiler REQUIRED)
+find_package_handle_standard_args(SYCL REQUIRED_VARS SYCL_LIBRARY)


### PR DESCRIPTION
Using [oneMKL interface](https://github.com/oneapi-src/oneMKL) instead of the [oneMKL library](https://www.intel.com/content/www/us/en/docs/oneapi/programming-guide/2023-0/intel-oneapi-math-kernel-library-onemkl.html) when building this benchmarks adds flexibility, as oneMKL can use different backends, including the oneMKL library itself.