### PR TITLE
[Cudasift][SYCL] removed USE_DEFAULT_FLAGS

### DIFF
--- a/cudaSift/SYCL/CMakeLists.txt
+++ b/cudaSift/SYCL/CMakeLists.txt
@@ -89,7 +89,6 @@ endif()
 
 # Use either default or user defined CXX flags
 # -DCMAKE_CXX_FLAGS=" -blah -blah " overrides the default flags
-set(USE_DEFAULT_FLAGS ON)
 
 set(DEF_INTEL_WL_CXX_FLAGS  " ")
 set(DEF_NVIDIA_WL_CXX_FLAGS " ")


### PR DESCRIPTION
Removed USE_DEFAULT_FLAGS flag from Cmake script which is no more required.