### PR TITLE
[Cudasift] Used LowPassBlock instead of LowPassBlockOld

### DIFF
--- a/cudaSift/CUDA/cudaSiftH.cu
+++ b/cudaSift/CUDA/cudaSiftH.cu
@@ -502,7 +502,7 @@ double LowPass(CudaImage &res, CudaImage &src, float scale, float &totTime)
 #ifdef DEVICE_TIMER
   auto start_kernel = std::chrono::steady_clock::now();
 #endif
-  LowPassBlockOld<<<blocks, threads>>>(src.d_data, res.d_data, width, pitch, height);
+  LowPassBlock<<<blocks, threads>>>(src.d_data, res.d_data, width, pitch, height);
   safeCall(cudaDeviceSynchronize());
 #ifdef DEVICE_TIMER
   auto stop_kernel = std::chrono::steady_clock::now();

--- a/cudaSift/HIP/cudaSiftH.cpp
+++ b/cudaSift/HIP/cudaSiftH.cpp
@@ -552,7 +552,7 @@ double LowPass(CudaImage &res, CudaImage &src, float scale, float &totTime)
 #ifdef DEVICE_TIMER
   auto start_kernel = std::chrono::steady_clock::now();
 #endif
-  hipLaunchKernelGGL(LowPassBlockOld, blocks, threads, 0, 0, src.d_data, res.d_data, width, pitch, height);
+  hipLaunchKernelGGL(LowPassBlock, blocks, threads, 0, 0, src.d_data, res.d_data, width, pitch, height);
   hipDeviceSynchronize();
 
 #ifdef DEVICE_TIMER

--- a/cudaSift/SYCL/cudaSiftH.dp.cpp
+++ b/cudaSift/SYCL/cudaSiftH.dp.cpp
@@ -679,7 +679,7 @@ double LowPass(CudaImage &res, CudaImage &src, float scale, sycl::queue &q_ct, f
 #if !defined(USE_NVIDIA_BACKEND) && !defined(USE_AMDHIP_BACKEND)
                                           [[intel::reqd_sub_group_size(32)]]
 #endif
-                                         { LowPassBlockOld(src_data_ct1, res_data_ct1, width, pitch, height, item_ct1,
+                                         { LowPassBlock(src_data_ct1, res_data_ct1, width, pitch, height, item_ct1,
                                                            d_LowPassKernel_ptr_ct1, xrows_acc_ct1); }); })
         .wait();
 #ifdef DEVICE_TIMER


### PR DESCRIPTION
- Used LowPassBlock function instead of LowPassBlockOld to address the issue of verification failure when loop unrolling is removed in SYCL version.
- Used the same function in CUDA and HIP versions too.