### PR TITLE
[reverse_time_migration] Insert <cmath> header

### DIFF
--- a/reverse_time_migration/libs/SeismicOperations/src/components/concrete/oneapi/boundary-managers/extensions/MinExtension.cpp
+++ b/reverse_time_migration/libs/SeismicOperations/src/components/concrete/oneapi/boundary-managers/extensions/MinExtension.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cmath>
 
 using namespace sycl;
 using namespace std;


### PR DESCRIPTION
- In preparation for `sycl.hpp` for removing `cmath.h`