### PR TITLE
[ethminer] Remove unreachable default case in switch statements to prevent potential performance regression.

### DIFF
--- a/ethminer/libethash-sycl/dagger_shuffled.dp.hpp
+++ b/ethminer/libethash-sycl/dagger_shuffled.dp.hpp
@@ -85,6 +85,7 @@ DEV_INLINE bool compute_hash(uint64_t nonce, sycl::uint2 *mix_hash, sycl::nd_ite
             shuffle[7].x() = item_ct1.get_sub_group().shuffle(state[7].x(), i + p + iShuffleOffset);
             shuffle[7].y() = item_ct1.get_sub_group().shuffle(state[7].y(), i + p + iShuffleOffset);
 
+            assert(mix_idx <= 3);
 
             switch (mix_idx) {
             case 0:
@@ -96,9 +97,9 @@ DEV_INLINE bool compute_hash(uint64_t nonce, sycl::uint2 *mix_hash, sycl::nd_ite
             case 2:
                 mix[p] = vectorize2(shuffle[4], shuffle[5]);
                 break;
-            case 3:
-                mix[p] = vectorize2(shuffle[6], shuffle[7]);
-                break;
+            default:
+              mix[p] = vectorize2(shuffle[6], shuffle[7]);
+              break;
             }
 
             init0[p] = item_ct1.get_sub_group().shuffle(shuffle[0].x(), iShuffleOffset);
@@ -182,6 +183,7 @@ DEV_INLINE bool compute_hash(uint64_t nonce, sycl::uint2 *mix_hash, sycl::nd_ite
             shuffle_7.y() = item_ct1.get_sub_group().shuffle(state[7].y(), i + p + iShuffleOffset);
 
             /////}
+            assert(mix_idx <= 3);
 
             switch (mix_idx) {
             case 0:
@@ -193,9 +195,9 @@ DEV_INLINE bool compute_hash(uint64_t nonce, sycl::uint2 *mix_hash, sycl::nd_ite
             case 2:
                 mix[p] = vectorize2(shuffle_4, shuffle_5);
                 break;
-            case 3:
-                mix[p] = vectorize2(shuffle_6, shuffle_7);
-                break;
+            default:
+              mix[p] = vectorize2(shuffle_6, shuffle_7);
+              break;
             }
 
             init0[p] = item_ct1.get_sub_group().shuffle(shuffle_0.x(), iShuffleOffset);


### PR DESCRIPTION
Addressing the issue of [Lower unreachable to exit to allow ptxas to accurately reconstruct the CFG](https://reviews.llvm.org/D152789) could potentially result in performance regression through adding a basic block with an `exit` to the end of the CFG. An example demonstrating noticeable regression resulting from this change can be found in [ethminer](https://github.com/oneapi-src/Velocity-Bench/tree/main/ethminer), where the code is built using DPC++ for the A100 CUDA backend, using below commands.
```
CC="clang" CXX="clang++ -fsycl -fsycl-unnamed-lambda" cmake .. -DUSE_SM=80 -DUSE_NVIDIA_BACKEND=ON -DETHASHSYCL=ON -G Ninja
ninja
```
The performance regression in the sample comes from a switch statement with an unreachable default which is lowered to `exit` and moved to the end of the CFG.

To address this issue, a [pull request](https://github.com/llvm/llvm-project/pull/72641) was submitted to upstream-llvm. However, it has not been accepted after multiple variations due to concerns about potential side-effects. One suggestion was to modify the source code, which the current pull request offers.

Running ethminer built using DPC++ for the CUDA backend with the command `ethminer -S -M 1` yielded the following measurements before the patch:
```
Total Execution Time: 61.409 s
Total Number of Hashes: 9316597760
Overall Hash Rate: 151.714 MH/s
```
With the patch applied, the performance improved as follows. It's worth noting that similar measurements will be observed when using a revision of DPC++ built before introduction of [Lower unreachable to exit to allow ptxas to accurately reconstruct the CFG](https://reviews.llvm.org/D152789):

```
Total Execution Time: 61.4018 s
Total Number of Hashes: 9462349824
Overall Hash Rate: 154.145 MH/s
```
This improvement indicates around 2% increase in overall hash rate, highlighting the significance of the change for the application's performance.