### PR TITLE
[Voxelizer] Updated CMake files in SYCL and HIP

### DIFF
--- a/THIRD-PARTY-PROGRAMS
+++ b/THIRD-PARTY-PROGRAMS
@@ -756,7 +756,7 @@ Library.
 	cxxopts
 	Copyright (c) 2014 Jarryd Beck
 
-  Voxelizer CUDA
+        Voxelizer CUDA
 	Copyright (c) 2019 Jeroen Baert
 	
 	Voxelizer HIP

--- a/THIRD-PARTY-PROGRAMS
+++ b/THIRD-PARTY-PROGRAMS
@@ -756,6 +756,17 @@ Library.
 	cxxopts
 	Copyright (c) 2014 Jarryd Beck
 
+  Voxelizer CUDA
+	Copyright (c) 2019 Jeroen Baert
+	
+	Voxelizer HIP
+	Modifications Copyright (C) 2023 Intel Corporation
+	Copyright (c) 2019 Jeroen Baert
+	
+	Voxelizer SYCL
+	Modifications Copyright (C) 2023 Intel Corporation
+	Copyright (c) 2019 Jeroen Baert
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/voxelizer/HIP/CMakeLists.txt
+++ b/voxelizer/HIP/CMakeLists.txt
@@ -30,7 +30,7 @@ option(Trimesh2_LINK_DIR "Path to Trimesh2 library dir")
 option(Trimesh2_INCLUDE_DIR "Path to Trimesh2 includes")
 option(GLM_INCLUDE_DIR "Path to GLM includes")
 
-set(DEF_WL_CXX_FLAGS " -D__HIP_PLATFORM_AMD__ ")
+set(DEF_WL_CXX_FLAGS " -D__HIP_PLATFORM_AMD__ -fPIE -Wl,-z,relro ")
 set(DEF_GENERAL_CXX_FLAGS " -Wall -O3 -Wextra ")
 set(DEF_COMBINED_CXX_FLAGS "${DEF_GENERAL_CXX_FLAGS} ${DEF_WL_CXX_FLAGS}")
 
@@ -38,7 +38,6 @@ include_directories(
   ${Trimesh2_INCLUDE_DIR}
 )
 
-# SET(GLM_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/glm/glm)
 FIND_PACKAGE(glm REQUIRED)
 message(STATUS "glm library status:")
 message(STATUS "    version: ${glm_VERSION}")
@@ -58,12 +57,11 @@ option(WG_SIZE "Specifies the block size")
 
 if("${CMAKE_CXX_FLAGS}" STREQUAL "")
   message(STATUS "Using DEFAULT compilation flags for the application")
-  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -O3 -std=c++17 -ffast-math -D__HIP_PLATFORM_AMD__ ")
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -O3 -std=c++20 -ffast-math -D__HIP_PLATFORM_AMD__ -fPIE -Wl,-z,relro ")
 else()
   message(STATUS "OVERRIDING compilation flags")
 endif()
 
-# set(HIP_PATH /opt/rocm-5.4.3/hip)
 find_package(HIP REQUIRED)
 
 if(NOT HIP_FOUND)
@@ -74,7 +72,6 @@ endif()
 
 SET(HIP_VOXELIZER_EXECUTABLE voxelizer_hip)
 
-# SET(GLM_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src)
 IF(NOT Trimesh2_INCLUDE_DIR)
   MESSAGE(FATAL_ERROR "You need to set variable Trimesh2_INCLUDE_DIR")
 ENDIF()
@@ -87,7 +84,6 @@ ENDIF()
 
 MARK_AS_ADVANCED(Trimesh2_TriMesh_h)
 
-# SET(Trimesh2_LINK_DIR CACHE PATH "Path to Trimesh2 library dir.")
 IF(NOT Trimesh2_LINK_DIR)
   MESSAGE(FATAL_ERROR "You need to set variable Trimesh2_LINK_DIR")
 ENDIF()
@@ -133,18 +129,15 @@ elseif(NOT "${CMAKE_CXX_FLAGS}" STREQUAL "")
   message(STATUS "OVERRIDING GENERAL and WORKLOAD SPECIFIC compilation flags")
 endif()
 
+set(HIP_INCLUDE_DIRS /opt/rocm-5.4.3/include)
 message(STATUS "CXX  Compilation flags to: ${CMAKE_CXX_FLAGS}")
+message(STATUS "HIP Include: ${HIP_INCLUDE_DIRS}")
 
-set(HIP_SEPARABLE_COMPILATION ON)
 set(MY_TARGET_NAME ${PROJECT_NAME})
-set(MY_HIPCC_OPTIONS)
-set(MY_NVCC_OPTIONS)
 set(CMAKE_HIP_ARCHITECTURES OFF)
+set(CMAKE_HIP_FLAGS ${CMAKE_CXX_FLAGS})
+hip_add_executable(${HIP_VOXELIZER_EXECUTABLE} ${HIP_VOXELIZER_SRCS})
 
-set_source_files_properties(${HIP_VOXELIZER_SRCS} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-hip_add_executable(${HIP_VOXELIZER_EXECUTABLE} ${HIP_VOXELIZER_SRCS} ${MY_HIPCC_OPTIONS} NVCC_OPTIONS ${MY_NVCC_OPTIONS})
-
-# include(${CMAKE_CURRENT_SOURCE_DIR}/src/glm/glm/CMakeLists.txt)
 TARGET_COMPILE_FEATURES(${HIP_VOXELIZER_EXECUTABLE} PRIVATE cxx_std_17)
-TARGET_INCLUDE_DIRECTORIES(${HIP_VOXELIZER_EXECUTABLE} PRIVATE ${Trimesh2_INCLUDE_DIR} ${GLM_INCLUDE_DIR})
+TARGET_INCLUDE_DIRECTORIES(${HIP_VOXELIZER_EXECUTABLE} PRIVATE ${Trimesh2_INCLUDE_DIR} ${GLM_INCLUDE_DIR} ${HIP_INCLUDE_DIRS})
 TARGET_LINK_LIBRARIES(${HIP_VOXELIZER_EXECUTABLE} ${Trimesh2_LIBRARY} glm::glm)

--- a/voxelizer/LICENSE
+++ b/voxelizer/LICENSE
@@ -1,0 +1,21 @@
+Modifications Copyright (C) 2023 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT

--- a/voxelizer/README.md
+++ b/voxelizer/README.md
@@ -79,7 +79,9 @@ libsrc/TriMesh_pointareas.cc
 
 mkdir build && cd build
 
-CXX=hipcc cmake ../ -DTrimesh2_INCLUDE_DIR=/path/to/trimesh2/include/ -DTrimesh2_LINK_DIR=/path/to/trimesh2/lib.Linux64 -DGLM_INCLUDE_DIR=/path/to/glm
+HIP_PATH=/opt/rocm-5.4.3/hip CXX=/opt/rocm-5.4.3/bin/hipcc cmake ../ -DTrimesh2_INCLUDE_DIR=/path/to/trimesh2/include/ -DTrimesh2_LINK_DIR=/path/to/trimesh2/lib.Linux64 -DGLM_INCLUDE_DIR=/path/to/glm
+
+make -sj
 
 **To run Hip version**
 

--- a/voxelizer/SYCL/CMakeLists.txt
+++ b/voxelizer/SYCL/CMakeLists.txt
@@ -76,8 +76,8 @@ ENDIF()
 
 MARK_AS_ADVANCED(Trimesh2_TriMesh_h)
 
-link_directories(${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64)
-SET(Trimesh2_LINK_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64/)
+#link_directories(${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64)
+#SET(Trimesh2_LINK_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64/)
 
 IF(NOT Trimesh2_LINK_DIR)
     MESSAGE(FATAL_ERROR "You need to set variable Trimesh2_LINK_DIR")

--- a/voxelizer/SYCL/CMakeLists.txt
+++ b/voxelizer/SYCL/CMakeLists.txt
@@ -26,8 +26,6 @@ PROJECT(voxelizer LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17) # SYCL code requires this
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # Enable modern C++ standards
 
-# set(CMAKE_CXX_EXTENSIONS OFF)        # Use -std, not -gnu
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
 option(ENABLE_KERNEL_PROFILING "Build using kernel profiling" OFF)
 option(GPU_AOT "Build AOT for Intel GPU" OFF)
 option(USE_NVIDIA_BACKEND "Build for NVIDIA backend" OFF)
@@ -38,12 +36,10 @@ option(USE_SM "Specifies which streaming multiprocessor architecture to use")
 option(Trimesh2_LINK_DIR "Path to Trimesh2 library dir")
 option(Trimesh2_INCLUDE_DIR "Path to Trimesh2 includes")
 
-# list(APPEND CMAKE_PREFIX_PATH "/home/anudeep/dev/dependencies/test/glm")
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/
 )
 
-# SET(glm_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/glm)
 find_package(glm REQUIRED)
 message(STATUS "glm library status:")
 message(STATUS "    version: ${glm_VERSION}")
@@ -63,7 +59,6 @@ message(STATUS "    include path: ${GLM_INCLUDE_DIRS}")
 # message(STATUS "    include path: ${OpenMP_INCLUDE_DIRS}")
 SET(VOXELIZER_EXECUTABLE voxelizer_sycl)
 
-# SET(Trimesh2_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/include/)
 IF(NOT Trimesh2_INCLUDE_DIR)
     MESSAGE(FATAL_ERROR "You need to set variable Trimesh2_INCLUDE_DIR")
 ENDIF()
@@ -75,9 +70,6 @@ IF(NOT Trimesh2_TriMesh_h)
 ENDIF()
 
 MARK_AS_ADVANCED(Trimesh2_TriMesh_h)
-
-#link_directories(${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64)
-#SET(Trimesh2_LINK_DIR ${CMAKE_SOURCE_DIR}/../../../dependencies/test/trimesh2/lib.Linux64/)
 
 IF(NOT Trimesh2_LINK_DIR)
     MESSAGE(FATAL_ERROR "You need to set variable Trimesh2_LINK_DIR")
@@ -108,8 +100,6 @@ SET(SOURCES
     ${CMAKE_SOURCE_DIR}/src/voxelize_solid.dp.cpp
 )
 
-# set(OPENMP_LIBRARIES "/usr/lib/llvm-10/lib")
-# set(OPENMP_INCLUDES "/usr/lib/llvm-10/include")
 if(USE_NVIDIA_BACKEND)
     message(STATUS "Nvidia backend")
     add_compile_options(-DUSE_NVIDIA_BACKEND)


### PR DESCRIPTION
- Updated cmake files for SYCL and HIP versions to fix build issues.
- Updates THIRD-PARTY-PROGRAMS file to add voxelizer license info
- Added voxelizer license file inside its voxelizer folder