### PR TITLE
[Cudasift][SYCL] Remove deprecated api

### DIFF
--- a/cudaSift/SYCL/infra/device.hpp
+++ b/cudaSift/SYCL/infra/device.hpp
@@ -204,21 +204,8 @@ namespace infra
       prop.set_host_unified_memory(
           get_info<sycl::info::device::host_unified_memory>());
 
-      // max_clock_frequency parameter is not supported on host device
-      if (is_host())
-      {
-        // This code may need to be updated. Currently max_clock_frequency for
-        // host device is initialized with 1, in assumption that if other devices
-        // exist and they are being selected based on this parameter, other
-        // devices would have higher priority.
-        prop.set_max_clock_frequency(1);
-      }
-      else
-      {
-        prop.set_max_clock_frequency(
+      prop.set_max_clock_frequency(
             get_info<sycl::info::device::max_clock_frequency>());
-      }
-
       prop.set_max_compute_units(
           get_info<sycl::info::device::max_compute_units>());
       prop.set_max_work_group_size(


### PR DESCRIPTION
Removed the usage of ishost api which is deprecated from the SYCLOS compiler.