### PR TITLE
[ethminer][SYCL] Limit number of registers for CUDA backend

### DIFF
--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -50,7 +50,7 @@ option(USE_SM                  "Build for CUDA architecture"     )
 
 ### SYCL RELATED FLAGS START HERE
 set(DEF_INTEL_GENERAL_CXX_FLAGS  " -O2 -fsycl ")
-set(DEF_NVIDIA_GENERAL_CXX_FLAGS " -O3 -fsycl ")
+set(DEF_NVIDIA_GENERAL_CXX_FLAGS " -O3 -fsycl -Xcuda-ptxas --maxrregcount=64 ")
 set(DEF_AMD_GENERAL_CXX_FLAGS    " -O3 -fsycl ")
 
 set(DEF_INTEL_WL_CXX_FLAGS  " ")


### PR DESCRIPTION
Add the compilation flag `-Xcuda-ptxas --maxrregcount=64` for the SYCL CUDA backend.

CUDA allows maximum of 64k registers per SM, which is maximum of 64 registers per work-item in case of work group size of 1024. DPC++ output currently produces a binary using 84 registers per work-item, resulting in a failure to launch a kernel at runtime. The extra flag works around the issue by forcing the register limit.

Tested with Compute Capability 8.0 and 8.6 GPUs, but the same limits apply to all NVIDIA architectures.