### PR TITLE
[SeisAcoMod2D][CUDA] Fix incorrect linking flags

### DIFF
--- a/SeisAcoMod2D/CUDA/CMakeLists.txt
+++ b/SeisAcoMod2D/CUDA/CMakeLists.txt
@@ -84,4 +84,4 @@ include_directories(
 
 cuda_add_executable(SeisAcoMod2D ${SOURCES})
 
-target_link_libraries(SeisAcoMod2D -L${MPI_HOME}/lib -L${MPI_CXX_LIBRARIES} -L${CUDA_LIBRARIES})
+target_link_libraries(SeisAcoMod2D -L${MPI_HOME}/lib ${MPI_CXX_LIBRARIES} ${CUDA_LIBRARIES})


### PR DESCRIPTION
The flag `-L` should be only applied to directories containing libraries, not to absolute paths to library files. Fix the flags by removing `-L` which was resulting in flags like these being added: `-L/path/to/libmpicxx.so -L/path/to/libcudart_static.a` and the linker failing.