### PR TITLE
[voxelizer][SYCL] Remove host-device workaround

### DIFF
--- a/voxelizer/SYCL/src/infra/device.hpp
+++ b/voxelizer/SYCL/src/infra/device.hpp
@@ -214,20 +214,8 @@ namespace infra
       prop.set_host_unified_memory(
           get_info<sycl::info::device::host_unified_memory>());
 
-      // max_clock_frequency parameter is not supported on host device
-      if (is_host())
-      {
-        // This code may need to be updated. Currently max_clock_frequency for
-        // host device is initialized with 1, in assumption that if other devices
-        // exist and they are being selected based on this parameter, other
-        // devices would have higher priority.
-        prop.set_max_clock_frequency(1);
-      }
-      else
-      {
-        prop.set_max_clock_frequency(
-            get_info<sycl::info::device::max_clock_frequency>());
-      }
+      prop.set_max_clock_frequency(
+          get_info<sycl::info::device::max_clock_frequency>() * 1000);
 
       prop.set_max_compute_units(
           get_info<sycl::info::device::max_compute_units>());


### PR DESCRIPTION
Fix the old copy of DPCT device.hpp header by replacing the `set_max_clock_frequency` configuration with a version from a recent DPCT release. The old code called the function `is_host()` which was not defined anywhere in this repository and failed to compile. There is no host device in SYCL2020 anyway, so the removed branch would never be taken.