### PR TITLE
[easywave] Print both total and compute-only times

### DIFF
--- a/easywave/CUDA/src/EasyWave.cpp
+++ b/easywave/CUDA/src/EasyWave.cpp
@@ -83,8 +83,8 @@ int commandLineHelp(void);
 
 int main(int argc, char **argv)
 {
-    Timer tWallClock("WallClock");
-    tWallClock.Start();
+    Timer tWallClockTotal("WallClockTotal");
+    tWallClockTotal.Start();
     LOG("Starting CUDA main program. Process ID: " << Utility::GetProcessID());
     Utility::QueryCUDADevice();
 
@@ -148,6 +148,9 @@ int main(int argc, char **argv)
     if (Par.outPropagation) {
         ewStart2DOutput();
     }
+
+    Timer tWallClockCompute("WallClockCompute");
+    tWallClockCompute.Start();
 
     Node.copyToGPU();
 
@@ -236,9 +239,11 @@ int main(int argc, char **argv)
     delete gNode;
 
     LOG("Program successfully completed");
-    tWallClock.Stop();
-    LOG("I/O Time            : " << dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
-    LOG("Total Execution Time: " << tWallClock.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
+    tWallClockTotal.Stop();
+    tWallClockCompute.Stop();
+    LOG("I/O Time            : " << dAccumulatedIOWriteTime + dAccumulateIOReadTime << " s");
+    LOG("Compute Time        : " << tWallClockCompute.GetTime() << " s");
+    LOG("Total Execution Time: " << tWallClockTotal.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
     return 0;
 }
 

--- a/easywave/HIP/src/EasyWaveGen.cpp
+++ b/easywave/HIP/src/EasyWaveGen.cpp
@@ -82,8 +82,8 @@ int commandLineHelp(void);
 
 int main(int argc, char **argv)
 {
-    Timer tWallClock("WallClock");
-    tWallClock.Start();
+    Timer tWallClockTotal("WallClockTotal");
+    tWallClockTotal.Start();
     LOG("Starting HIP main program. Process ID: " << Utility::GetProcessID());
     Utility::QueryHIPDevice();
 
@@ -148,6 +148,9 @@ int main(int argc, char **argv)
     if (Par.outPropagation) {
         ewStart2DOutput();
     }
+
+    Timer tWallClockCompute("WallClockCompute");
+    tWallClockCompute.Start();
 
     Node.copyToGPU();
 
@@ -237,9 +240,11 @@ int main(int argc, char **argv)
     delete gNode;
 
     LOG("Program successfully completed");
-    tWallClock.Stop();
-    LOG("I/O Time            : " << dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
-    LOG("Total Execution Time: " << tWallClock.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
+    tWallClockTotal.Stop();
+    tWallClockCompute.Stop();
+    LOG("I/O Time            : " << dAccumulatedIOWriteTime + dAccumulateIOReadTime << " s");
+    LOG("Compute Time        : " << tWallClockCompute.GetTime() << " s");
+    LOG("Total Execution Time: " << tWallClockTotal.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
     return 0;
 }
 

--- a/easywave/SYCL/src/EasyWave.cpp
+++ b/easywave/SYCL/src/EasyWave.cpp
@@ -83,8 +83,8 @@ int commandLineHelp(void);
 
 int main(int argc, char **argv)
 {
-    Timer tWallClock("WallClock");
-    tWallClock.Start();
+    Timer tWallClockTotal("WallClockTotal");
+    tWallClockTotal.Start();
     LOG("Starting SYCL main program"); ///. Process ID: " << Utility::GetProcessID());
 
     std::vector<std::string> eWaveFiles(Utility::FileHandler::GetFilesFromDirectory(Utility::FileHandler::GetCurrentDirectory()));
@@ -147,6 +147,9 @@ int main(int argc, char **argv)
 
     if (Par.outPropagation)
         ewStart2DOutput();
+
+    Timer tWallClockCompute("WallClockCompute");
+    tWallClockCompute.Start();
 
     Node.copyToGPU();
 
@@ -237,9 +240,11 @@ int main(int argc, char **argv)
     delete gNode;
 
     LOG("Program successfully completed");
-    tWallClock.Stop();
-    LOG("I/O Time            : " << dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
-    LOG("Total Execution Time: " << tWallClock.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
+    tWallClockTotal.Stop();
+    tWallClockCompute.Stop();
+    LOG("I/O Time            : " << dAccumulatedIOWriteTime + dAccumulateIOReadTime << " s");
+    LOG("Compute Time        : " << tWallClockCompute.GetTime() << " s");
+    LOG("Total Execution Time: " << tWallClockTotal.GetTime() - dAccumulatedIOWriteTime - dAccumulateIOReadTime << " s");
     return 0;
 }
 


### PR DESCRIPTION
Add an extra timer to measure just the computation time without initialisation. Print both at the end.

Also fix the I/O time printout which should be the sum of read and write, not the difference.