### PR TITLE
[dl-mnist] Print both total and compute-only times

### DIFF
--- a/dl-mnist/CUDA/main.cudnn.cpp
+++ b/dl-mnist/CUDA/main.cudnn.cpp
@@ -64,6 +64,8 @@ int main(int argc, const char** argv) {
         cout << "=======================================================================" << endl;
         cout << endl;
 
+        Time wallClockCompute = get_time_now();
+
         WorkloadParams workload_params(argc, argv);
         
         
@@ -151,13 +153,21 @@ int main(int argc, const char** argv) {
 #ifdef DEVICE_TIMER            
         cout << "Final time across all networks: " << timer->getTotalOpTime() << " s" << std::endl;
 #endif
+
+        double computeTime = calculate_op_time_taken(wallClockCompute);
+
         delete dlNetworkMgr;
         delete timer;
 
         if (handle) cudnnDestroy(handle);
 
-        std::cout << "dl-mnist - total time for whole calculation: " << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime()<< " s" << std::endl;    
-    
+        double totalTime = calculate_op_time_taken(wallClockStart);
+        double ioTime = dataFileReadTimer->getTotalOpTime();
+
+        std::cout << "dl-mnist - I/O time: " << ioTime << " s" << std::endl;
+        std::cout << "dl-mnist - compute time: " << computeTime - ioTime << " s" << std::endl;
+        std::cout << "dl-mnist - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
+
     } catch (DlInfraException& e) {
         std::cout << e.what() << "\n";
         std::cout << "Workload execution failed" << std::endl;

--- a/dl-mnist/HIP/main.miopen.cpp
+++ b/dl-mnist/HIP/main.miopen.cpp
@@ -63,6 +63,8 @@ int main(int argc, const char** argv) {
     cout << "=======================================================================" << endl;
     cout << endl;
 
+    Time wallClockCompute = get_time_now();
+
     WorkloadParams workload_params(argc, argv);
     
     
@@ -151,14 +153,20 @@ int main(int argc, const char** argv) {
 #ifdef DEVICE_TIMER           
     cout << "Final time across all networks: " << timer->getTotalOpTime() << " s" << std::endl;
 #endif
+
+    double computeTime = calculate_op_time_taken(wallClockCompute);
+
     delete dlNetworkMgr;
     delete timer;
 
     if (handle) miopenDestroy(handle);
-    
 
-    std::cout << "dl-mnist - total time for whole calculation: " << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime()<< " s" << std::endl;    
+    double totalTime = calculate_op_time_taken(wallClockStart);
+    double ioTime = dataFileReadTimer->getTotalOpTime();
 
+    std::cout << "dl-mnist - I/O time: " << ioTime << " s" << std::endl;
+    std::cout << "dl-mnist - compute time: " << computeTime - ioTime << " s" << std::endl;
+    std::cout << "dl-mnist - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
 
 };
 

--- a/dl-mnist/SYCL/main.onednn.cpp
+++ b/dl-mnist/SYCL/main.onednn.cpp
@@ -89,6 +89,8 @@ int main(int argc, const char** argv) {
         cout << "=======================================================================" << endl;
         cout << endl;
 
+        Time wallClockCompute = get_time_now();
+
         WorkloadParams workload_params(argc, argv);
 
         // Since this workload is for inference, we are keeping N=1 which is the usual case for inference. 
@@ -172,6 +174,9 @@ int main(int argc, const char** argv) {
 #ifdef DEVICE_TIMER  
         cout << "Final time across all networks: " << timer->getTotalOpTime() << " s" << std::endl;
 #endif
+
+        double computeTime = calculate_op_time_taken(wallClockCompute);
+
         delete dlNetworkMgr;
 
         delete dht;
@@ -180,7 +185,13 @@ int main(int argc, const char** argv) {
 
         delete timer;
 
-        std::cout << "dl-mnist - total time for whole calculation: " << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime()<< " s" << std::endl;    
+        double totalTime = calculate_op_time_taken(wallClockStart);
+        double ioTime = dataFileReadTimer->getTotalOpTime();
+
+        std::cout << "dl-mnist - I/O time: " << ioTime << " s" << std::endl;
+        std::cout << "dl-mnist - compute time: " << computeTime - ioTime << " s" << std::endl;
+        std::cout << "dl-mnist - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
+
     } catch (dnnl::error& e) {
         std::cout << e.what() << "\n";
         std::cout << "Workload execution failed" << std::endl;


### PR DESCRIPTION
Add an extra timer to measure just the computation time without initialisation. Print both at the end.