### PR TITLE
[dl-cifar] Print both total and compute-only times

### DIFF
--- a/dl-cifar/CUDA/main.cuda.cpp
+++ b/dl-cifar/CUDA/main.cuda.cpp
@@ -60,13 +60,17 @@ int main(int argc, const char** argv) {
 
         DlCifarWorkloadParams workload_params(argc, argv);
 
+        Time wallClockCompute = get_time_now();
         VitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
         CaitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
 
+        double computeTime = calculate_op_time_taken(wallClockCompute);
+        double totalTime = calculate_op_time_taken(wallClockStart);
+        double ioTime = dataFileReadTimer->getTotalOpTime();
         
-        std::cout << "dataFileReadTimer->getTotalOpTime(): " << dataFileReadTimer->getTotalOpTime() << " s" << std::endl;
-        std::cout << "dl-cifar - total time for whole calculation: " 
-                                << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime() << " s" << std::endl;    
+        std::cout << "dl-cifar - I/O time: " << ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - compute time: " << computeTime - ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
 
         delete timer;
         delete dataFileReadTimer;

--- a/dl-cifar/HIP/main.hip.cpp
+++ b/dl-cifar/HIP/main.hip.cpp
@@ -57,13 +57,17 @@ int main(int argc, const char** argv) {
 
         DlCifarWorkloadParams workload_params(argc, argv);
 
+        Time wallClockCompute = get_time_now();
         VitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
         CaitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
 
+        double computeTime = calculate_op_time_taken(wallClockCompute);
+        double totalTime = calculate_op_time_taken(wallClockStart);
+        double ioTime = dataFileReadTimer->getTotalOpTime();
                
-        std::cout << "dataFileReadTimer->getTotalOpTime(): " << dataFileReadTimer->getTotalOpTime() << " s" << std::endl;
-        std::cout << "dl-cifar - total time for whole calculation: " 
-                                                << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime() << " s" << std::endl;    
+        std::cout << "dl-cifar - I/O time: " << ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - compute time: " << computeTime - ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
 
         delete timer;
         delete dataFileReadTimer;

--- a/dl-cifar/SYCL/main.sycl.cpp
+++ b/dl-cifar/SYCL/main.sycl.cpp
@@ -58,13 +58,17 @@ int main(int argc, const char** argv) {
 
         DlCifarWorkloadParams workload_params(argc, argv);
 
+        Time wallClockCompute = get_time_now();
         VitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
         CaitController::execute(workload_params.getDlNwSizeType(), langHandle, timer, dataFileReadTimer);
         
+        double computeTime = calculate_op_time_taken(wallClockCompute);
+        double totalTime = calculate_op_time_taken(wallClockStart);
+        double ioTime = dataFileReadTimer->getTotalOpTime();
         
-        std::cout << "dataFileReadTimer->getTotalOpTime(): " << dataFileReadTimer->getTotalOpTime() << " s" << std::endl;
-        std::cout << "dl-cifar - total time for whole calculation: " 
-                                << calculate_op_time_taken(wallClockStart) - dataFileReadTimer->getTotalOpTime() << " s" << std::endl;    
+        std::cout << "dl-cifar - I/O time: " << ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - compute time: " << computeTime - ioTime << " s" << std::endl;
+        std::cout << "dl-cifar - total time for whole calculation: " << totalTime - ioTime << " s" << std::endl;
 
         delete timer;
         delete dataFileReadTimer;


### PR DESCRIPTION
Add an extra timer to measure just the computation time without initialisation. Print both at the end.