### PR TITLE
[dl-cifar] Reduce the impact of host computations on benchmark results

### DIFF
--- a/dl-cifar/CUDA/CMakeLists.txt
+++ b/dl-cifar/CUDA/CMakeLists.txt
@@ -34,7 +34,7 @@ option(USE_SM                  "Specifies which streaming multiprocessor archite
 option(DEVICE_TIMER            "Build using Device Timer" OFF)
 
 set(DEF_WL_CXX_FLAGS           " ")
-set(DEF_GENERAL_CXX_FLAGS      " -O2 ")
+set(DEF_GENERAL_CXX_FLAGS      " -O3 -ffast-math ")
 set(DEF_COMBINED_CXX_FLAGS     "${DEF_GENERAL_CXX_FLAGS} ${DEF_WL_CXX_FLAGS}")
 
 set(SOURCES 

--- a/dl-cifar/HIP/CMakeLists.txt
+++ b/dl-cifar/HIP/CMakeLists.txt
@@ -33,7 +33,7 @@ option(DEVICE_TIMER            "Build using Device Timer" OFF)
 
 
 set(DEF_WL_CXX_FLAGS           " -D__HIP_PLATFORM_AMD__ ")
-set(DEF_GENERAL_CXX_FLAGS      " -Wall -O3 -Wextra ")
+set(DEF_GENERAL_CXX_FLAGS      " -Wall -O3 -ffast-math -Wextra ")
 set(DEF_COMBINED_CXX_FLAGS     "${DEF_GENERAL_CXX_FLAGS} ${DEF_WL_CXX_FLAGS}")
 
 

--- a/dl-cifar/common/image_processing.h
+++ b/dl-cifar/common/image_processing.h
@@ -102,10 +102,32 @@ namespace dl_cifar::common {
             static void initImage(float* image, int imageSize) {
                 Tracer::func_begin("ImageProcessor::initImage");
 
-                unsigned seed = 123456789;
-                for (int index = 0; index < imageSize; index++) {
+                struct ImageCache {
+                    size_t size{0};
+                    float* image{nullptr};
+                    ~ImageCache() {
+                        if (image==nullptr) {return;}
+                        delete[] image;
+                        image = nullptr;
+                    }
+                };
+                static ImageCache cache{};
+                static unsigned seed = 123456789;
+
+                // grow the cache allocation to image size
+                if (imageSize > cache.size) {
+                    float* newCacheImage = new float[imageSize];
+                    std::memcpy(newCacheImage, cache.image, cache.size*sizeof(float));
+                    delete[] cache.image;
+                    cache.image = newCacheImage;
+                }
+
+                // fill image with cached data and compute the remaining part
+                std::memcpy(image, cache.image, std::min(cache.size,static_cast<size_t>(imageSize))*sizeof(float));
+                for (; cache.size < imageSize; ++cache.size) {
                     seed         = (1103515245 * seed + 12345) & 0xffffffff;
-                    image[index] = float(seed) * 2.3283064e-10;  // 2^-32
+                    cache.image[cache.size-1] = float(seed) * 2.3283064e-10;  // 2^-32
+                    image[cache.size-1] = cache.image[cache.size-1];
                 }
                 Tracer::func_end("ImageProcessor::initImage");
 

--- a/dl-cifar/common/vit/vit.h
+++ b/dl-cifar/common/vit/vit.h
@@ -181,10 +181,10 @@ namespace dl_cifar::common {
                     ImageProcessor::resize(langHandle, d_cifarRawImgs, d_resizedImgs, selectedVitParams.batchSize, 
                                             VitConfigs::cifarNoOfChannels, VitConfigs::cifarImgWidth, VitConfigs::cifarImgWidth, 
                                             selectedVitParams.imgWidth, selectedVitParams.imgHeight); 
-                    ImageProcessor::resizeInHost(langHandle, h_cifarRawImgs, h_resizedImgs, selectedVitParams.batchSize, 
-                                            VitConfigs::cifarNoOfChannels, VitConfigs::cifarImgWidth, VitConfigs::cifarImgWidth, 
-                                            selectedVitParams.imgWidth, selectedVitParams.imgHeight); 
-                    langHandle->memCpyH2D(d_resizedImgs, h_resizedImgs, sizeof(float) * resizedSize, true);
+                    // ImageProcessor::resizeInHost(langHandle, h_cifarRawImgs, h_resizedImgs, selectedVitParams.batchSize,
+                    //                         VitConfigs::cifarNoOfChannels, VitConfigs::cifarImgWidth, VitConfigs::cifarImgWidth,
+                    //                         selectedVitParams.imgWidth, selectedVitParams.imgHeight);
+                    // langHandle->memCpyH2D(d_resizedImgs, h_resizedImgs, sizeof(float) * resizedSize, true);
 
 
 


### PR DESCRIPTION
The dl-cifar benchmark, especially with small workload size, suffers from significant impact of host computations on the overall measured computation time. This exacerbates any differences in compiler optimisations for host code between icpx, gcc and possibly other host compilers.

The differences between gcc and icpx as host compiler are greatly reduced with these three changes.

#### 1. Use -O3 -ffast-math in all versions
Only SYCL version used fast math and only SYCL and HIP used `-O3`, whereas CUDA used `-O2`. This created an unfair comparison between the programming models. Align the compilation flags to use `-O3 -ffast-math` everywhere.

#### 2. Comment out redundant host upsampling
This is already commented out in other places, but one was missed. The redundant upsampling on the host introduces large host overhead in the measured computation times and skews the comparison between offload programming models.

#### 3. Optimise initImage using static cache
The `initImage` function is called hundreds of times, repeating the same computations on the host each time. The redundant computation introduces large host overhead in the measured computation times and skews the comparison between offload programming models. Furthermore, icpx is far better than gcc at reducing this redundancy, resulting in large performance differences caused entirely by host computation and irrelevant to offloading performance.

Speed up the `initImage` function by using a static cache in order to minimise the host overheads in the benchmarked computation. This also aligns the host performance between icpx and gcc.
