### PR TITLE
[lc0][SYCL] Fix segfault

### DIFF
--- a/lc0/src/neural/sycl/layers.cc.dp.cpp
+++ b/lc0/src/neural/sycl/layers.cc.dp.cpp
@@ -1681,7 +1681,7 @@ void allocAndUpload(DataType** gpu_dest, std::vector<float> cpu_src,
     return;
   }
   
-  gpu_dest = (DataType **)sycl::malloc_device(size, sycl_queue);
+  *gpu_dest = sycl::malloc_device<DataType>(cpu_src.size(), sycl_queue);
 
   //sycl_queue.memcpy(scratch, &cpu_src[0], cpu_src.size() * sizeof(float)).wait();
   sycl_queue.memcpy(scratch, &cpu_src[0], cpu_src.size() * sizeof(float)).wait();


### PR DESCRIPTION
Fix incorrect dereference and assignment causing a segfault. Also use the templated `malloc_device` to avoid C-style casting and make the code clearer.

The code creates an uninitialised pointer and intends to assign a value to this pointer (location of newly allocated memory). However, it was previously trying to assign the value to the pointed-to location not the pointer itself, hence it was dereferencing the uninitialised pointer.